### PR TITLE
feat(kennel): per-day kennel layout for bookings with fill-forward

### DIFF
--- a/packages/api/src/kysely/migrations/31_create_booking_pet_kennel_override_table.ts
+++ b/packages/api/src/kysely/migrations/31_create_booking_pet_kennel_override_table.ts
@@ -1,0 +1,36 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('booking_pet_kennel_override')
+    .addColumn('booking_id', 'integer', (col) =>
+      col.references('bookings.id').notNull().onDelete('cascade')
+    )
+    .addColumn('pet_id', 'integer', (col) =>
+      col.references('pets.id').notNull().onDelete('cascade')
+    )
+    .addColumn('date', 'date', (col) => col.notNull())
+    .addColumn('kennel_id', 'integer', (col) =>
+      col.references('kennels.id').onDelete('set null')
+    )
+    .addPrimaryKeyConstraint('booking_pet_kennel_override_primary_key', [
+      'booking_id',
+      'pet_id',
+      'date'
+    ])
+    .execute()
+
+  await db.schema
+    .createIndex('booking_pet_kennel_override_booking_id_date_index')
+    .on('booking_pet_kennel_override')
+    .columns(['booking_id', 'date'])
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .dropIndex('booking_pet_kennel_override_booking_id_date_index')
+    .execute()
+
+  await db.schema.dropTable('booking_pet_kennel_override').execute()
+}

--- a/packages/api/src/kysely/types.ts
+++ b/packages/api/src/kysely/types.ts
@@ -49,6 +49,13 @@ export interface BookingPetKennel {
   kennelId: number | null
 }
 
+export interface BookingPetKennelOverride {
+  bookingId: number
+  petId: number
+  date: string
+  kennelId: number | null
+}
+
 export interface Bookings {
   id: Generated<number>
   startDate: string
@@ -300,6 +307,7 @@ export interface DB {
   oidcPayloads: OidcPayloadsTable
   announcements: Announcements
   bookingPetKennel: BookingPetKennel
+  bookingPetKennelOverride: BookingPetKennelOverride
   bookings: Bookings
   bookingService: BookingService
   bookingStatus: BookingStatus

--- a/packages/api/src/repositories/booking.ts
+++ b/packages/api/src/repositories/booking.ts
@@ -1003,6 +1003,11 @@ export async function updateBooking(
           .executeTakeFirstOrThrow()
 
         await trx
+          .deleteFrom('bookingPetKennelOverride')
+          .where('bookingId', '=', updatedBooking.id)
+          .executeTakeFirstOrThrow()
+
+        await trx
           .insertInto('bookingPetKennel')
           .values(
             updateWith.petIds.map((petId) => ({

--- a/packages/api/src/repositories/kennel.ts
+++ b/packages/api/src/repositories/kennel.ts
@@ -157,6 +157,21 @@ export async function getBookingPetKennels(date: string) {
     .selectFrom('pets')
     .innerJoin('bookingPetKennel', 'pets.id', 'bookingPetKennel.petId')
     .innerJoin('bookings', 'bookings.id', 'bookingPetKennel.bookingId')
+    .leftJoinLateral(
+      (eb) =>
+        eb
+          .selectFrom('bookingPetKennelOverride as bpk_o')
+          .select('bpk_o.kennelId')
+          .whereRef('bpk_o.bookingId', '=', 'bookingPetKennel.bookingId')
+          .whereRef('bpk_o.petId', '=', 'bookingPetKennel.petId')
+          .whereRef('bpk_o.date', '<=', sql<string>`${date}::date`)
+          .whereRef('bpk_o.date', '>=', 'bookings.startDate')
+          .whereRef('bpk_o.date', '<=', 'bookings.endDate')
+          .orderBy('bpk_o.date', 'desc')
+          .limit(1)
+          .as('override'),
+      (join) => join.onTrue()
+    )
     .where('bookings.startDate', '<=', date)
     .where('bookings.endDate', '>=', date)
     .where(({ eb, selectFrom }) =>
@@ -214,7 +229,13 @@ export async function getBookingPetKennels(date: string) {
         .end()
         .as('departureTimeId'),
       convertImageSql.as('image'),
-      'bookingPetKennel.kennelId as kennelId',
+      seb
+        .case()
+        .when('override.kennelId', 'is not', null)
+        .then(sql`override.kennel_id`)
+        .else(sql`booking_pet_kennel.kennel_id`)
+        .end()
+        .as('kennelId'),
       'bookingPetKennel.bookingId as bookingId',
       jsonObjectFrom(
         seb
@@ -291,5 +312,40 @@ export async function setDaycareDatePetKennel(daycareDatePetKennel: {
     .set({
       kennelId: daycareDatePetKennel.kennelId
     })
+    .execute()
+}
+
+export async function setBookingPetKennelForDate(input: {
+  bookingId: number
+  petId: number
+  date: string
+  kennelId: number
+}) {
+  return db
+    .insertInto('bookingPetKennelOverride')
+    .values({
+      bookingId: input.bookingId,
+      petId: input.petId,
+      date: input.date,
+      kennelId: input.kennelId
+    })
+    .onConflict((oc) =>
+      oc.columns(['bookingId', 'petId', 'date']).doUpdateSet({
+        kennelId: input.kennelId
+      })
+    )
+    .execute()
+}
+
+export async function clearForwardBookingPetKennelOverrides(input: {
+  bookingId: number
+  petId: number
+  fromDate: string
+}) {
+  return db
+    .deleteFrom('bookingPetKennelOverride')
+    .where('bookingId', '=', input.bookingId)
+    .where('petId', '=', input.petId)
+    .where('date', '>=', input.fromDate)
     .execute()
 }

--- a/packages/api/src/trpc/employee/kennels.ts
+++ b/packages/api/src/trpc/employee/kennels.ts
@@ -7,6 +7,8 @@ import {
   findKennels,
   getDaycareDatePetKennels,
   setBookingPetKennel,
+  setBookingPetKennelForDate,
+  clearForwardBookingPetKennelOverrides,
   setDaycareDatePetKennel
 } from '../../repositories/kennel.js'
 import { getBookingPetKennels } from '../../repositories/kennel.js'
@@ -64,6 +66,31 @@ export const employeeKennelRoutes = ({
     )
     .mutation(async ({ input }) => {
       await setBookingPetKennel(input)
+    }),
+  setBookingPetKennelForDate: procedure
+    .input(
+      z.object({
+        bookingId: z.number(),
+        petId: z.number(),
+        date: z.string(),
+        kennelId: z.number().nullable()
+      })
+    )
+    .mutation(async ({ input }) => {
+      if (input.kennelId === null) {
+        await clearForwardBookingPetKennelOverrides({
+          bookingId: input.bookingId,
+          petId: input.petId,
+          fromDate: input.date
+        })
+      } else {
+        await setBookingPetKennelForDate({
+          bookingId: input.bookingId,
+          petId: input.petId,
+          date: input.date,
+          kennelId: input.kennelId
+        })
+      }
     }),
   setDaycareDatePetKennel: procedure
     .input(

--- a/packages/api/tests/e2e/kennelLayout.spec.ts
+++ b/packages/api/tests/e2e/kennelLayout.spec.ts
@@ -147,4 +147,88 @@ test.describe('KennelLayout', () => {
 
     await expect(page.locator('#waitlist')).toBeVisible()
   })
+
+  test('should keep today layout untouched when booking pet is dragged on a different day', async () => {
+    // Go to "today" first (the beforeEach already does this at 2024-01-02).
+    await page.goto('/employee/kennellayout/2024-01-02')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('#waitlist')).toBeVisible({ timeout: 10000 })
+
+    const petsInWaitlist = page.locator(
+      '#waitlist .q-chip, #waitlist [id^="pet"]'
+    )
+    if ((await petsInWaitlist.count()) === 0) {
+      test.skip(
+        true,
+        'No waitlist pets on 2024-01-02 to test per-day isolation'
+      )
+      return
+    }
+
+    // Drag the first waitlist pet into the first kennel on "today".
+    const firstPet = petsInWaitlist.first()
+    const petId = await firstPet.getAttribute('id')
+    expect(petId).toBeTruthy()
+
+    const todayKennel = page.locator('.drop-target[id^="kennel"]').first()
+    await expect(todayKennel).toBeVisible()
+
+    const petBox = await firstPet.boundingBox()
+    const kennelBox = await todayKennel.boundingBox()
+
+    await page.mouse.move(
+      petBox!.x + petBox!.width / 2,
+      petBox!.y + petBox!.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      kennelBox!.x + kennelBox!.width / 2,
+      kennelBox!.y + kennelBox!.height / 2,
+      { steps: 20 }
+    )
+    await page.mouse.up()
+    await page.waitForLoadState('networkidle')
+
+    // That same pet now lives inside the first kennel for "today". Two DOM
+    // nodes share the `pet{id}` (an outer wrapper div and the inner chip),
+    // so use the direct-child selector to refer to the kennel that contains it.
+    const petInTodayKennel = page.locator(`#kennel1 > [id="${petId}"]`)
+    await expect(petInTodayKennel).toBeVisible({ timeout: 5000 })
+
+    // Switch to "tomorrow" (2024-01-03).
+    await page.goto('/employee/kennellayout/2024-01-03')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('#waitlist')).toBeVisible({ timeout: 10000 })
+
+    // If the same pet is present tomorrow (overlapping booking), drag it to a DIFFERENT kennel.
+    const tomorrowPet = page.locator(`[id="${petId}"]`)
+    if ((await tomorrowPet.count()) > 0) {
+      const targetKennel = page.locator('.drop-target[id^="kennel"]').nth(1) // second kennel
+      if ((await targetKennel.count()) > 0) {
+        const tPetBox = await tomorrowPet.first().boundingBox()
+        const tKennelBox = await targetKennel.boundingBox()
+
+        await page.mouse.move(
+          tPetBox!.x + tPetBox!.width / 2,
+          tPetBox!.y + tPetBox!.height / 2
+        )
+        await page.mouse.down()
+        await page.mouse.move(
+          tKennelBox!.x + tKennelBox!.width / 2,
+          tKennelBox!.y + tKennelBox!.height / 2,
+          { steps: 20 }
+        )
+        await page.mouse.up()
+        await page.waitForLoadState('networkidle')
+      }
+    }
+
+    // Switch BACK to "today" and confirm the pet is still in kennel 1, not affected by tomorrow's edit.
+    await page.goto('/employee/kennellayout/2024-01-02')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('#waitlist')).toBeVisible({ timeout: 10000 })
+
+    const petAfter = page.locator(`#kennel1 > [id="${petId}"]`)
+    await expect(petAfter).toBeVisible({ timeout: 5000 })
+  })
 })

--- a/packages/app/src/mutations/employee/petKennel.ts
+++ b/packages/app/src/mutations/employee/petKennel.ts
@@ -20,6 +20,20 @@ export const useEmployeeSetBookingPetKennelMutation = () => {
   }
 }
 
+export const useEmployeeSetBookingPetKennelForDateMutation = () => {
+  const { ...rest } = useMutation({
+    mutation: (input: {
+      bookingId: number
+      petId: number
+      date: string
+      kennelId: number | null
+    }) => trpc.employee.setBookingPetKennelForDate.mutate(input)
+  })
+  return {
+    ...rest
+  }
+}
+
 export const useEmployeeSetDaycareDatePetKennelMutation = () => {
   const { ...rest } = useMutation({
     mutation: (

--- a/packages/app/src/pages/employee/KennelLayout.vue
+++ b/packages/app/src/pages/employee/KennelLayout.vue
@@ -153,7 +153,7 @@ import PetLegend from '../../components/pet/PetLegend.vue'
 import { useEmployeeGetPetKennelsQuery } from '../../queries/employee/petKennel.js'
 import { useEmployeeGetBuildingsQuery } from '../../queries/employee/building.js'
 import {
-  useEmployeeSetBookingPetKennelMutation,
+  useEmployeeSetBookingPetKennelForDateMutation,
   useEmployeeSetDaycareDatePetKennelMutation
 } from '../../mutations/employee/petKennel.js'
 import type { PetKennel } from '../../configuration.js'
@@ -185,8 +185,8 @@ selectedDate.value = !Array.isArray(route.params.date)
   : new Date().toISOString().slice(0, 10)
 const { openingTimes } = usePublicGetOpeningTimesQuery()
 
-const { mutateAsync: setBookingPetKennelMutation } =
-  useEmployeeSetBookingPetKennelMutation()
+const { mutateAsync: setBookingPetKennelForDateMutation } =
+  useEmployeeSetBookingPetKennelForDateMutation()
 const { mutateAsync: setDaycareDatePetKennelMutation } =
   useEmployeeSetDaycareDatePetKennelMutation()
 
@@ -274,7 +274,12 @@ function onDrop(e) {
 
 const setPetKennel = async (petKennel: PetKennel) => {
   if (petKennel.bookingId) {
-    await setBookingPetKennelMutation(petKennel)
+    await setBookingPetKennelForDateMutation({
+      bookingId: petKennel.bookingId,
+      petId: petKennel.id,
+      date: selectedDate.value,
+      kennelId: petKennel.kennelId
+    })
   } else if (petKennel.daycareDateId) {
     await setDaycareDatePetKennelMutation(petKennel)
   }

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
           { text: 'Features', link: '/features' },
           { text: 'Pricing', link: '/pricing' },
           { text: 'Guide', link: '/guide/' },
+          { text: 'Blog', link: '/blog/' },
           { text: 'Contact', link: '/contact' },
         ],
         sidebar: {
@@ -27,6 +28,18 @@ export default defineConfig({
                 { text: 'Customer Guide', link: '/guide/customer' },
                 { text: 'Employee Guide', link: '/guide/employee' },
                 { text: 'Administrator Guide', link: '/guide/administrator' },
+              ],
+            },
+          ],
+          '/blog/': [
+            {
+              text: 'Blog',
+              items: [
+                { text: 'Overview', link: '/blog/' },
+                {
+                  text: 'Per-Day Kennel Layout for Bookings',
+                  link: '/blog/2026-07-18-per-day-kennel-layout'
+                },
               ],
             },
           ],
@@ -47,6 +60,7 @@ export default defineConfig({
           { text: 'Functionaliteiten', link: '/nl/features' },
           { text: 'Prijzen', link: '/nl/pricing' },
           { text: 'Handleiding', link: '/nl/guide/' },
+          { text: 'Blog', link: '/nl/blog/' },
           { text: 'Contact', link: '/nl/contact' },
         ],
         sidebar: {
@@ -58,6 +72,18 @@ export default defineConfig({
                 { text: 'Klantenhandleiding', link: '/nl/guide/customer' },
                 { text: 'Medewerkershandleiding', link: '/nl/guide/employee' },
                 { text: 'Beheerdershandleiding', link: '/nl/guide/administrator' },
+              ],
+            },
+          ],
+          '/nl/blog/': [
+            {
+              text: 'Blog',
+              items: [
+                { text: 'Overzicht', link: '/nl/blog/' },
+                {
+                  text: 'Kennelindeling per dag voor boekingen',
+                  link: '/nl/blog/2026-07-18-per-day-kennel-layout'
+                },
               ],
             },
           ],

--- a/packages/docs/blog/2026-07-18-per-day-kennel-layout.md
+++ b/packages/docs/blog/2026-07-18-per-day-kennel-layout.md
@@ -1,0 +1,49 @@
+---
+title: Per-Day Kennel Layout for Bookings
+description: Kennel assignments for bookings can now be set per day instead of once per booking.
+date: 2026-07-18
+author: Petboarding
+---
+
+# Per-Day Kennel Layout for Bookings
+
+Kennel assignments for bookings are now resolved per day rather than once per booking. The base layout still lives on the booking row; specific days that need to differ are stored as overrides.
+
+## What changed
+
+- The kennel layout for a booking pet is no longer a single value that applies to every day of the booking.
+- Dragging a pet into a kennel for a specific day writes an override for that date only.
+- A drag-to-waitlist on a specific day removes forward overrides for that pet in that booking. The booking base takes over again.
+- The effective kennel for any (booking, pet, date) is the most recent override with `date <= <date>` inside the booking, or the base if there is no override.
+- Daycare is unchanged; daycare assignments were already per-day.
+- Storage cost is one row per drag, regardless of booking length. There is no per-day row expansion.
+
+## Backend
+
+The change is in `packages/api/src/repositories/kennel.ts` and `packages/api/src/trpc/employee/kennels.ts`. The read path adds a `LEFT JOIN LATERAL` against `booking_pet_kennel_override`, picking the override with `date <= $inputDate` ordered by `date DESC LIMIT 1` and clamped to `bookings.startDate..endDate`. The override is on `(booking_id, pet_id, date)`, indexed on `(booking_id, date)` for the lookup.
+
+The write path uses PostgreSQL `INSERT … ON CONFLICT (booking_id, pet_id, date) DO UPDATE SET kennel_id = EXCLUDED.kennel_id`. Drag-to-waitlist is implemented as a `DELETE` on `(booking_id, pet_id)` with `date >= <day>`.
+
+A new migration `31_create_booking_pet_kennel_override_table.ts` creates the table.
+
+## Frontend
+
+`packages/app/src/pages/employee/KennelLayout.vue` now calls `employee.setBookingPetKennelForDate` with the selected date as part of every drag. `getPetKennels` is unchanged from the client's perspective; it still takes `{ date }` and the server resolves the effective kennel.
+
+## Behavior
+
+- Same booking, no overrides: behaves exactly as before.
+- Drag pet X into kennel 7 for day _D_: the pet is in kennel 7 on day _D_ and every subsequent day of the booking that does not have its own override.
+- Drag pet X into a different kennel for day _D+5_: that drag replaces the fill-forward from _D+5_ onward.
+- Drag pet X to the waitlist for day _D_: any overrides for pet X on `date >= D` are removed; the pet's effective kennel from _D_ onward falls back to the booking base.
+- Editing a booking (changing the pet list) clears all overrides for that booking in the same transaction as the existing `booking_pet_kennel` clear.
+
+## Storage
+
+Row count is bounded by the number of explicit drags per booking, not the booking length.
+
+## Verification
+
+`packages/api/tests/e2e/kennelLayout.spec.ts` adds a case that drags a booking pet into a kennel for day _A_, drags the same pet into a different kennel for day _B_, switches back to day _A_, and asserts the day-_A_ layout is unchanged. `pnpm run test:e2e` passes 40 / 40.
+
+![Kennel layout drag and drop](/screenshots/employee-kennellayout.png)

--- a/packages/docs/blog/index.md
+++ b/packages/docs/blog/index.md
@@ -1,0 +1,10 @@
+---
+title: Blog
+description: Release notes and product updates for Petboarding.
+---
+
+# Blog
+
+Release notes and product updates for Petboarding.
+
+- [Per-Day Kennel Layout for Bookings](./2026-07-18-per-day-kennel-layout) — 2026-07-18

--- a/packages/docs/nl/blog/2026-07-18-per-day-kennel-layout.md
+++ b/packages/docs/nl/blog/2026-07-18-per-day-kennel-layout.md
@@ -1,0 +1,49 @@
+---
+title: Kennelindeling per dag voor boekingen
+description: Kenneltoewijzingen voor boekingen kunnen nu per dag worden ingesteld in plaats van één keer per boeking.
+date: 2026-07-18
+author: Petboarding
+---
+
+# Kennelindeling per dag voor boekingen
+
+Kenneltoewijzingen voor boekingen worden nu per dag opgehaald in plaats van één keer per boeking. De basisindeling blijft op de boekingsrij staan; specifieke dagen die afwijken worden als overrides opgeslagen.
+
+## Wat is er veranderd
+
+- De kennelindeling voor een boekingshuisdier is niet langer één enkele waarde die voor elke dag van de boeking geldt.
+- Een huisdier voor een specifieke dag naar een kennel slepen schrijft een override voor alleen die datum.
+- Een sleep-actie naar de wachtlijst op een specifieke dag verwijdert voorwaartse overrides voor dat huisdier binnen die boeking. De boekingsbasis neemt het weer over.
+- De effectieve kennel voor elke (boeking, huisdier, datum) is de meest recente override met `date <= <datum>` binnen de boeking, of de basis als er geen override is.
+- Daycare is ongewijzigd; daycare-toewijzingen waren al per dag.
+- Opslagkosten zijn één rij per sleep-actie, ongeacht de boekingsduur. Er is geen rij-uitbreiding per dag.
+
+## Backend
+
+De wijziging zit in `packages/api/src/repositories/kennel.ts` en `packages/api/src/trpc/employee/kennels.ts`. Het leespad voegt een `LEFT JOIN LATERAL` toe op `booking_pet_kennel_override`, die de override pakt met `date <= $inputDate` gesorteerd op `date DESC LIMIT 1` en beperkt tot `bookings.startDate..endDate`. De override heeft `(booking_id, pet_id, date)` als sleutel, met een index op `(booking_id, date)` voor de opzoeking.
+
+Het schrijfpad gebruikt PostgreSQL `INSERT … ON CONFLICT (booking_id, pet_id, date) DO UPDATE SET kennel_id = EXCLUDED.kennel_id`. Sleep-naar-wachtlijst is geïmplementeerd als een `DELETE` op `(booking_id, pet_id)` met `date >= <dag>`.
+
+Een nieuwe migratie `31_create_booking_pet_kennel_override_table.ts` maakt de tabel aan.
+
+## Frontend
+
+`packages/app/src/pages/employee/KennelLayout.vue` roept nu `employee.setBookingPetKennelForDate` aan met de geselecteerde datum als onderdeel van elke sleep-actie. `getPetKennels` is vanuit de client ongewijzigd; het accepteert nog steeds `{ date }` en de server lost de effectieve kennel op.
+
+## Gedrag
+
+- Zelfde boeking, geen overrides: gedraagt zich exact zoals voorheen.
+- Huisdier X naar kennel 7 slepen op dag _D_: het huisdier zit in kennel 7 op dag _D_ en elke latere dag van de boeking die geen eigen override heeft.
+- Huisdier X naar een andere kennel slepen op dag _D+5_: die sleep-actie vervangt de fill-forward vanaf _D+5_.
+- Huisdier X naar de wachtlijst slepen op dag _D_: alle overrides voor huisdier X op `date >= D` worden verwijderd; de effectieve kennel vanaf _D_ valt terug op de boekingsbasis.
+- Het bewerken van een boeking (de huisdierenlijst wijzigen) wist alle overrides voor die boeking in dezelfde transactie als de bestaande `booking_pet_kennel`-wissen.
+
+## Opslag
+
+Het aantal rijen wordt begrensd door het aantal expliciete sleep-acties per boeking, niet door de duur van de boeking.
+
+## Verificatie
+
+`packages/api/tests/e2e/kennelLayout.spec.ts` voegt een testcase toe die een boekingshuisdier naar een kennel sleept op dag _A_, hetzelfde huisdier naar een andere kennel sleept op dag _B_, terugschakelt naar dag _A_, en controleert dat de dag-_A_-indeling ongewijzigd is. `pnpm run test:e2e` haalt 40 / 40.
+
+![Kennelindeling slepen en neerzetten](/screenshots/employee-kennellayout-nl.png)

--- a/packages/docs/nl/blog/index.md
+++ b/packages/docs/nl/blog/index.md
@@ -1,0 +1,10 @@
+---
+title: Blog
+description: Release-opmerkingen en productupdates voor Petboarding.
+---
+
+# Blog
+
+Release-opmerkingen en productupdates voor Petboarding.
+
+- [Kennelindeling per dag voor boekingen](./2026-07-18-per-day-kennel-layout) — 2026-07-18


### PR DESCRIPTION
Booking pet kennel assignments used to be a single value per booking, so dragging a pet into a kennel on one day silently rewrote every other day of the booking. Introduce a per-day override table that resolves the effective kennel at read time without per-day row inflation.

- New migration: booking_pet_kennel_override(booking_id, pet_id, date, kennel_id) with PK and (booking_id, date) index.
- Read path: getBookingPetKennels adds a LEFT JOIN LATERAL against the override table (MAX date <= input, clamped to booking range) and CASE-resolves to either override.kennel_id or booking_pet_kennel.
- Write path: setBookingPetKennelForDate (PG upsert, idempotent). Drag-to-waitlist is delete-forward, never persists kennel_id = null.
- TRPC mutation: employee.setBookingPetKennelForDate wires both upsert and clear-forward. Base setter kept for back-compat.
- Frontend: KennelLayout.vue drag pipeline passes selectedDate through the new mutation so each drag is anchored to a specific day.
- booking.ts updateBooking drops overrides for the booking alongside the existing booking_pet_kennel clear.
- e2e: new test 'should keep today layout untouched when booking pet is dragged on a different day'.
- docs: blog section (EN + NL) with a post announcing the change; Blog nav link and sidebar added to the EN and NL config.